### PR TITLE
minor tweaks

### DIFF
--- a/tests/test_idempotence.sh
+++ b/tests/test_idempotence.sh
@@ -89,8 +89,8 @@ done
 
 # the name of the Vagrant box or host name
 BOX=${BOX:-localhost}
-# the Ansible inventory in the form of a file or string "host,"
-INVENTORY=${INVENTORY:-'localhost,'}
+# the Ansible inventory
+INVENTORY=${INVENTORY:-'.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory'}
 # the path to the Ansible test playbook
 PLAYBOOK=${PLAYBOOK:-test.yml}
 # the logfile to hold the output of the playbook run
@@ -98,13 +98,15 @@ LOGFILE="log/${BOX}_${VIRTUALENV_NAME}.log"
 
 EXTRA_ARGS=''
 if [ $BOX == "localhost" ]; then
-    EXTRA_ARGS="--connection=local --extra-vars idempotence=yes --extra-vars env=${ENV}"
+    INVENTORY='localhost,'
+    EXTRA_ARGS="--connection=local -e idempotence=yes -e env=${ENV} -e vagrant_box=localhost"
 else
-    EXTRA_ARGS="--u vagrant --extra-vars idempotence=yes --extra-vars env=vagrant"
+    EXTRA_ARGS="--user vagrant --e idempotence=yes -e env=vagrant -e vagrant_box=${BOX}"
 fi
 
 echo "[INFO] ${BOX} ${VIRTUALENV_NAME} running idempotence test..."
-ansible-playbook -i ${INVENTORY} --limit ${BOX}, ${EXTRA_ARGS} ${PLAYBOOK} 2>&1 | tee ${LOGFILE} | \
+ansible-playbook -vvvv -i ${INVENTORY} --limit ${BOX}, ${EXTRA_ARGS} ${PLAYBOOK} 2>&1 | \
+    tee ${LOGFILE} | \
     grep "${BOX}" | grep -q "${PASS_CRITERIA}" && \
     echo -ne "[TEST] ${BOX} ${VIRTUALENV_NAME} idempotence : ${GREEN}PASS${NC}\n" || \
     (echo -ne "[TEST] ${BOX} ${VIRTUALENV_NAME} idempotence : ${RED}FAILED${NC} ${PASS_CRITERIA}\n" && cat ${LOGFILE} && exit 1)

--- a/tests/test_idempotence.sh
+++ b/tests/test_idempotence.sh
@@ -3,7 +3,7 @@
 #
 # Bash script to run idempotence tests.
 #
-# version: 1.4
+# version: 1.5
 #
 # usage:
 #
@@ -29,6 +29,9 @@
 #
 # changelog:
 #
+#   v1.5 :  8 Mar 2016
+#     - pass vagrant_box variable to playbook
+#     - default inventory changed from localhost to match what Vagrant provisioner generates
 #   v1.4 : 10 Jul 2015
 #     - added extra variables to force running idempotence tests on vagrant
 #   v1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-#    {py27}-{ansible193,ansible184,ansible172,ansible1610,ansible155,ansible145,ansible134,ansible123}
-    {py27}-{ansible193,ansible184,ansible172}
+    {py27}-{ansible2010,ansible194}
 
 skipsdist = True
 
@@ -9,17 +8,11 @@ skipsdist = True
 [testenv]
 changedir = tests
 deps =
-    travis: ansible==1.9.3
-    ansible193: ansible==1.9.3
-    ansible184: ansible==1.8.4
-    ansible172: ansible==1.7.2
-#    ansible1610: ansible==1.6.10
-#    ansible155: ansible==1.5.5
-#    ansible145: ansible==1.4.5
-#    ansible134: ansible==1.3.4
-#    ansible123: ansible==1.2.3
+    travis: ansible
+    ansible2002: ansible==2.0.1.0
+    ansible194: ansible==1.9.4
 
-passenv = ANSIBLE_ASK_SUDO_PASS HOME
+passenv = ANSIBLE_ASK_SUDO_PASS HOME LANG LC_ALL
 
 commands =
     bash -c "test -s ../requirements.yml && ansible-galaxy install --force -r ../requirements.yml || true"
@@ -34,19 +27,10 @@ passenv = ANSIBLE_ASK_SUDO_PASS HOME TRAVIS
 
 commands =
     bash -c "test -s ../requirements.yml && ansible-galaxy install --force -r ../requirements.yml || true"
-    ansible-playbook -i localhost, --connection=local test.yml {posargs} --skip-tags=test
+    ansible-playbook -i localhost, --connection=local test.yml -e vagrant_box=localhost {posargs} --skip-tags=test
     bash test_idempotence.sh --env travis
 
 whitelist_externals =
     ansible-playbook
     bash
 
-
-[testenv:docs]
-# sphinx documentation checks
-changedir = docs
-deps =
-    Sphinx
-
-commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
- [drop usage of `hosts: all` on test playbook](https://github.com/ansiblebit/primogen/issues/8)
- on test_idempotence default inventory changed to what Vagrant provisions
- increased playbook verbosity when testing
- updated ansible versions to test against
- pass LANG and LC_ALL environment variables to tox virtual environments
