### PR TITLE
travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ sudo: yes
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27-ansible194
-    - python: 2.7
-      env: TOXENV=py27-ansible2010
+    - env: TOXENV=py27-ansible21
+    - env: TOXENV=py27-ansible20
+    - env: TOXENV=py27-ansible19
 
 install:
   - pip install tox
 
 script:
-  - tox -e travis
+  - tox

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,4 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# #################
+#
+# Bash script to setup the test environment.
+#
+# version: 1.0
+#
+# usage:
+#
+#   setup.sh
+#
+# example:
+#
+#   bash setup.sh
+#
+# changelog:
+#
+#   v1.0 :  10 June 2016
+#     - initial version
+#
+# author(s):
+#   - Pedro Salgado <steenzout@ymail.com>
+#
+# #################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+test -s ${DIR}/../requirements.yml \
+    && ansible-galaxy install \
+        --force \
+        -r ${DIR}/../requirements.yml \
+        --roles-path=${DIR}/dependencies \
+    || true

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,4 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# #################
+#
+# Bash script to run tests in the travis-ci environment.
+#
+# version: 1.0
+#
+# usage:
+#
+#   travis.sh
+#
+# example:
+#
+#   bash travis.sh
+#
+# changelog:
+#
+#   v1.0 :  10 June 2016
+#     - initial version
+#
+# author(s):
+#   - Pedro Salgado <steenzout@ymail.com>
+#
+# #################
 
 test $USER = 'travis' \
     && ansible-playbook \

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+test $USER = 'travis' \
+    && ansible-playbook \
+        -i localhost, \
+        --connection=local test.yml \
+        -e vagrant_box=localhost \
+        -e env=travis \
+        --skip-tags=test \
+        $@ \
+    && bash test_checkmode.sh \
+        --env travis \
+    && bash test_idempotence.sh \
+        --env travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
 envlist =
-    {py27}-{ansible2010,ansible194}
+    {py27}-{ansible21,ansible20,ansible19}
 
 skipsdist = True
 
 
 [testenv]
 changedir = tests
+
 deps =
-    travis: ansible
-    ansible2010: ansible==2.0.1.0
-    ansible194: ansible==1.9.4
+    ansible21: ansible==2.1.*
+    ansible20: ansible==2.0.*
+    ansible19: ansible==1.9.*
 
 passenv = ANSIBLE_ASK_SUDO_PASS HOME LANG LC_ALL
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,26 +13,12 @@ deps =
     ansible20: ansible==2.0.*
     ansible19: ansible==1.9.*
 
-passenv = ANSIBLE_ASK_SUDO_PASS HOME LANG LC_ALL
+passenv = ANSIBLE_ASK_SUDO_PASS HOME LANG LC_ALL TRAVIS USER
 
 commands =
-    bash -c "test -s ../requirements.yml && ansible-galaxy install --force -r ../requirements.yml --roles-path=dependencies || true"
-    bash vagrant.sh {posargs}
-
-whitelist_externals =
-    bash
-
-
-[testenv:travis]
-passenv = ANSIBLE_ASK_SUDO_PASS HOME TRAVIS
-
-commands =
-    bash -c "test -s ../requirements.yml && ansible-galaxy install --force -r ../requirements.yml --roles-path=dependencies || true"
-    ansible-playbook -i localhost, --connection=local test.yml -e vagrant_box=localhost {posargs} -e env=travis --skip-tags=test
-    bash test_checkmode.sh --env travis
-    bash test_idempotence.sh --env travis
+    bash setup.sh
+    bash -c "test $USER = 'travis' && bash travis.sh {posargs} || bash vagrant.sh {posargs}"
 
 whitelist_externals =
     ansible-playbook
     bash
-


### PR DESCRIPTION
- tox will now install the latest minor version of [Ansible](https://www.ansible.com)
- travis-ci will now run ansible version tests in parallel
- added `setup.sh` script to easily setup dependencies
- added `travis.sh` to test role in [travis-ci](https://travis-ci.org/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansiblebit/primogen/17)
<!-- Reviewable:end -->
